### PR TITLE
Add WebAssembly build script and compression shim

### DIFF
--- a/build-scripts/build-wasm
+++ b/build-scripts/build-wasm
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+SRCDIR=$(cd "$(dirname "$0")"/.. && pwd)
+BUILD_DIR="$SRCDIR/build-wasm"
+rm -rf "$BUILD_DIR"
+emcmake cmake -S "$SRCDIR" -B "$BUILD_DIR" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DQPDF_BUILD_TESTS=OFF \
+  -DQPDF_BUILD_DOC=OFF \
+  -DQPDF_BUILD_EXAMPLES=OFF \
+  -DBUILD_SHARED_LIBS=OFF
+cmake --build "$BUILD_DIR" --target libqpdf
+LIB=$(find "$BUILD_DIR" -name libqpdf.a | head -n 1)
+emcc "$SRCDIR/wasm/shim.cc" "$LIB" -O3 \
+  -I"$SRCDIR/include" \
+  -s MODULARIZE=1 \
+  -s EXPORTED_FUNCTIONS='["_qpdf_wasm_compress"]' \
+  -o "$BUILD_DIR/qpdf-wasm.js"
+echo "WASM module created at $BUILD_DIR/qpdf-wasm.js"

--- a/wasm/shim.cc
+++ b/wasm/shim.cc
@@ -1,0 +1,17 @@
+#include <qpdf/QPDF.hh>
+#include <qpdf/QPDFWriter.hh>
+#include <exception>
+
+extern "C" int qpdf_wasm_compress(char const* infilename, char const* outfilename)
+{
+    try {
+        QPDF pdf;
+        pdf.processFile(infilename);
+        QPDFWriter w(pdf, outfilename);
+        w.setCompressStreams(true);
+        w.write();
+        return 0;
+    } catch (std::exception& e) {
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary
- add build script for compiling qpdf to WebAssembly via Emscripten
- provide C++ shim exposing qpdf_wasm_compress for PDF stream compression

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_6898cbfc38708330a16e63d9cdc450a9