### PR TITLE
Add configure step to WASM build script

### DIFF
--- a/build-scripts/build-wasm
+++ b/build-scripts/build-wasm
@@ -1,19 +1,36 @@
 #!/bin/bash
-set -e
+
+set -xeuo pipefail
+
 SRCDIR=$(cd "$(dirname "$0")"/.. && pwd)
 BUILD_DIR="$SRCDIR/build-wasm"
+EMSDK_HOME="${EMSDK_HOME:-/home/ubuntu/3rdParty/emsdk}"
+
+# Load emscripten environment
+source "$EMSDK_HOME/emsdk_env.sh" >/dev/null
+
+configure() {
+    emcmake cmake -S "$SRCDIR" -B "$BUILD_DIR" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DQPDF_BUILD_TESTS=OFF \
+        -DQPDF_BUILD_DOC=OFF \
+        -DQPDF_BUILD_EXAMPLES=OFF \
+        -DBUILD_SHARED_LIBS=OFF
+}
+
+build() {
+    cmake --build "$BUILD_DIR" --target libqpdf
+    local lib
+    lib=$(find "$BUILD_DIR" -name libqpdf.a | head -n 1)
+    emcc "$SRCDIR/wasm/shim.cc" "$lib" -O3 \
+        -I"$SRCDIR/include" \
+        -s MODULARIZE=1 \
+        -s EXPORTED_FUNCTIONS='["_qpdf_wasm_compress"]' \
+        -o "$BUILD_DIR/qpdf-wasm.js"
+}
+
 rm -rf "$BUILD_DIR"
-emcmake cmake -S "$SRCDIR" -B "$BUILD_DIR" \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DQPDF_BUILD_TESTS=OFF \
-  -DQPDF_BUILD_DOC=OFF \
-  -DQPDF_BUILD_EXAMPLES=OFF \
-  -DBUILD_SHARED_LIBS=OFF
-cmake --build "$BUILD_DIR" --target libqpdf
-LIB=$(find "$BUILD_DIR" -name libqpdf.a | head -n 1)
-emcc "$SRCDIR/wasm/shim.cc" "$LIB" -O3 \
-  -I"$SRCDIR/include" \
-  -s MODULARIZE=1 \
-  -s EXPORTED_FUNCTIONS='["_qpdf_wasm_compress"]' \
-  -o "$BUILD_DIR/qpdf-wasm.js"
+configure
+build
 echo "WASM module created at $BUILD_DIR/qpdf-wasm.js"
+


### PR DESCRIPTION
## Summary
- improve build-wasm script
- load Emscripten SDK from default path and add configure step

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_6898f7532ac883308052e5021c617511