### PR TITLE
Remove C++20 concept to restore C++17 compatibility

### DIFF
--- a/include/qpdf/QPDFWriter.hh
+++ b/include/qpdf/QPDFWriter.hh
@@ -24,7 +24,6 @@
 #include <qpdf/Types.h>
 
 #include <bitset>
-#include <concepts>
 #include <cstdio>
 #include <functional>
 #include <list>
@@ -33,6 +32,7 @@
 #include <set>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <vector>
 
 #include <qpdf/Constants.h>
@@ -462,7 +462,8 @@ class QPDFWriter
     void writeBinary(unsigned long long val, unsigned int bytes);
     QPDFWriter& write(std::string_view str);
     QPDFWriter& write(size_t count, char c);
-    QPDFWriter& write(std::integral auto val);
+    template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+    QPDFWriter& write(T val);
     QPDFWriter& write_name(std::string const& str);
     QPDFWriter& write_string(std::string const& str, bool force_binary = false);
     QPDFWriter& write_encrypted(std::string_view str);

--- a/libqpdf/QPDFWriter.cc
+++ b/libqpdf/QPDFWriter.cc
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <stdexcept>
+#include <type_traits>
 
 using namespace std::literals;
 using namespace qpdf;
@@ -1045,8 +1046,9 @@ QPDFWriter::write(std::string_view str)
     return *this;
 }
 
+template <typename T, typename>
 QPDFWriter&
-QPDFWriter::write(std::integral auto val)
+QPDFWriter::write(T val)
 {
     m->pipeline->write(std::to_string(val));
     return *this;


### PR DESCRIPTION
## Summary
- avoid `std::integral` concept in QPDFWriter helper and use SFINAE instead
- include `<type_traits>` to support the new template

## Testing
- `g++ -std=c++20 -Iinclude -Ilibqpdf -c libqpdf/QPDFWriter.cc -o /tmp/QPDFWriter.o` *(fails: qpdf/qpdf-config.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689929e26b148330bb48730a37fc4f4e