### PR TITLE
Ensure wasm demo runs from build directory

### DIFF
--- a/build-scripts/build-wasm
+++ b/build-scripts/build-wasm
@@ -35,6 +35,7 @@ build() {
         -s USE_LIBJPEG=1 \
         -s EXPORTED_FUNCTIONS='["_qpdf_wasm_compress"]' \
         -o "$BUILD_DIR/qpdf-wasm.js"
+    cp "$SRCDIR/wasm/index.html" "$BUILD_DIR"
 }
 
 rm -rf "$BUILD_DIR"

--- a/build-scripts/build-wasm-no-config
+++ b/build-scripts/build-wasm-no-config
@@ -25,6 +25,7 @@ build() {
         -s USE_LIBJPEG=1 \
         -s EXPORTED_FUNCTIONS='["_qpdf_wasm_compress"]' \
         -o "$BUILD_DIR/qpdf-wasm.js"
+    cp "$SRCDIR/wasm/index.html" "$BUILD_DIR"
 }
 
 build

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -7,7 +7,7 @@
 <body>
   <input type="file" id="file" accept="application/pdf" />
   <button id="run">Compress</button>
-  <script src="qpdf.js"></script>
+  <script src="qpdf-wasm.js"></script>
   <script>
     let ready = false;
     Module.onRuntimeInitialized = () => {


### PR DESCRIPTION
## Summary
- Load generated `qpdf-wasm.js` from wasm demo HTML
- Copy demo `index.html` into `build-wasm` output for easy use

## Testing
- `bash -n build-scripts/build-wasm build-scripts/build-wasm-no-config`


------
https://chatgpt.com/codex/tasks/task_e_6899371a8c948330a0c724d35cb5c05d