### PR TITLE
Ensure FS is exported for WASM demo

### DIFF
--- a/build-scripts/build-wasm
+++ b/build-scripts/build-wasm
@@ -34,6 +34,7 @@ build() {
         -s USE_ZLIB=1 \
         -s USE_LIBJPEG=1 \
         -s EXPORTED_FUNCTIONS='["_qpdf_wasm_compress"]' \
+        -s EXPORTED_RUNTIME_METHODS='["FS"]' \
         -o "$BUILD_DIR/qpdf-wasm.js"
     cp "$SRCDIR/wasm/index.html" "$BUILD_DIR"
 }

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -31,6 +31,12 @@
       const buf = new Uint8Array(await file.arrayBuffer());
       const input = 'input.pdf';
       const output = 'output.pdf';
+      // qpdf.FS is Emscripten's in-memory filesystem used to pass data between
+      // JavaScript and the WebAssembly module.
+      if (!qpdf.FS) {
+        alert('Filesystem support not available in this build');
+        return;
+      }
       qpdf.FS.writeFile(input, buf);
       qpdf.ccall('qpdf_wasm_compress', 'number', ['string', 'string'], [input, output]);
       const out = qpdf.FS.readFile(output);


### PR DESCRIPTION
## Summary
- Export Emscripten FS runtime so `qpdf-wasm.js` exposes filesystem APIs
- Guard browser demo against missing FS and explain its role

## Testing
- `bash -n build-scripts/build-wasm`


------
https://chatgpt.com/codex/tasks/task_e_689955935de88330b668bfd7384f2b6d