### PR TITLE
Enable filesystem support for WASM build

### DIFF
--- a/build-scripts/build-wasm
+++ b/build-scripts/build-wasm
@@ -33,6 +33,7 @@ build() {
         -s MODULARIZE=1 \
         -s USE_ZLIB=1 \
         -s USE_LIBJPEG=1 \
+        -s FORCE_FILESYSTEM=1 \
         -s EXPORTED_FUNCTIONS='["_qpdf_wasm_compress"]' \
         -s EXPORTED_RUNTIME_METHODS='["FS"]' \
         -o "$BUILD_DIR/qpdf-wasm.js"

--- a/build-scripts/build-wasm-no-config
+++ b/build-scripts/build-wasm-no-config
@@ -23,7 +23,9 @@ build() {
         -s MODULARIZE=1 \
         -s USE_ZLIB=1 \
         -s USE_LIBJPEG=1 \
+        -s FORCE_FILESYSTEM=1 \
         -s EXPORTED_FUNCTIONS='["_qpdf_wasm_compress"]' \
+        -s EXPORTED_RUNTIME_METHODS='["FS"]' \
         -o "$BUILD_DIR/qpdf-wasm.js"
     cp "$SRCDIR/wasm/index.html" "$BUILD_DIR"
 }


### PR DESCRIPTION
## Summary
- ensure Emscripten filesystem support is included when building qpdf's WASM demo

## Testing
- `bash -n build-scripts/build-wasm`
- `bash -n build-scripts/build-wasm-no-config`


------
https://chatgpt.com/codex/tasks/task_e_68995d5481108330aeb99bd9751d0e1d