### PR TITLE
Add memory filesystem fallback for wasm demo

### DIFF
--- a/wasm/index.html
+++ b/wasm/index.html
@@ -32,27 +32,39 @@
         return;
       }
       const file = fi.files[0];
-      const root = await navigator.storage?.getDirectory?.();
-      if (!qpdf.FS || !qpdf.FS.filesystems?.OPFS || !root) {
-        alert('OPFS not supported in this browser');
-        return;
+      if (qpdf.FS && qpdf.FS.filesystems?.OPFS && navigator.storage?.getDirectory) {
+        const root = await navigator.storage.getDirectory();
+        const inputHandle = await root.getFileHandle('input.pdf', { create: true });
+        const writable = await inputHandle.createWritable();
+        await file.stream().pipeTo(writable);
+        const input = '/opfs/input.pdf';
+        const output = '/opfs/output.pdf';
+        qpdf.ccall('qpdf_wasm_compress', 'number', ['string', 'string'], [input, output]);
+        const outHandle = await root.getFileHandle('output.pdf');
+        const outFile = await outHandle.getFile();
+        const url = URL.createObjectURL(outFile);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'compressed.pdf';
+        a.click();
+        URL.revokeObjectURL(url);
+        await root.removeEntry('input.pdf');
+        await root.removeEntry('output.pdf');
+      } else {
+        const buf = new Uint8Array(await file.arrayBuffer());
+        qpdf.FS.writeFile('input.pdf', buf);
+        qpdf.ccall('qpdf_wasm_compress', 'number', ['string', 'string'], ['input.pdf', 'output.pdf']);
+        const out = qpdf.FS.readFile('output.pdf');
+        const blob = new Blob([out], { type: 'application/pdf' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'compressed.pdf';
+        a.click();
+        URL.revokeObjectURL(url);
+        qpdf.FS.unlink('input.pdf');
+        qpdf.FS.unlink('output.pdf');
       }
-      const inputHandle = await root.getFileHandle('input.pdf', { create: true });
-      const writable = await inputHandle.createWritable();
-      await file.stream().pipeTo(writable);
-      const input = '/opfs/input.pdf';
-      const output = '/opfs/output.pdf';
-      qpdf.ccall('qpdf_wasm_compress', 'number', ['string', 'string'], [input, output]);
-      const outHandle = await root.getFileHandle('output.pdf');
-      const outFile = await outHandle.getFile();
-      const url = URL.createObjectURL(outFile);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'compressed.pdf';
-      a.click();
-      URL.revokeObjectURL(url);
-      await root.removeEntry('input.pdf');
-      await root.removeEntry('output.pdf');
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- allow wasm demo to run when OPFS is unavailable by using in-memory filesystem

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68996483617c833091634853027a5769