### PR TITLE
Export memory allocation functions for wasm build

### DIFF
--- a/build-scripts/build-wasm
+++ b/build-scripts/build-wasm
@@ -34,7 +34,7 @@ build() {
         -s USE_ZLIB=1 \
         -s USE_LIBJPEG=1 \
         -s FORCE_FILESYSTEM=1 \
-        -s EXPORTED_FUNCTIONS='["_qpdf_wasm_compress"]' \
+        -s EXPORTED_FUNCTIONS='["_qpdf_wasm_compress","_malloc","_free"]' \
         -s EXPORTED_RUNTIME_METHODS='["FS"]' \
         -o "$BUILD_DIR/qpdf-wasm.js"
     cp "$SRCDIR/wasm/index.html" "$BUILD_DIR"

--- a/build-scripts/build-wasm-no-config
+++ b/build-scripts/build-wasm-no-config
@@ -24,7 +24,7 @@ build() {
         -s USE_ZLIB=1 \
         -s USE_LIBJPEG=1 \
         -s FORCE_FILESYSTEM=1 \
-        -s EXPORTED_FUNCTIONS='["_qpdf_wasm_compress"]' \
+        -s EXPORTED_FUNCTIONS='["_qpdf_wasm_compress","_malloc","_free"]' \
         -s EXPORTED_RUNTIME_METHODS='["FS"]' \
         -o "$BUILD_DIR/qpdf-wasm.js"
     cp "$SRCDIR/wasm/index.html" "$BUILD_DIR"


### PR DESCRIPTION
## Summary
- expose `_malloc` and `_free` in wasm build scripts so index.html can allocate memory

## Testing
- `bash -n build-scripts/build-wasm build-scripts/build-wasm-no-config`


------
https://chatgpt.com/codex/tasks/task_e_68997c9374348330806132b9d49ad129