### PR TITLE
Enable PDF stream compression in WebAssembly shim

### DIFF
--- a/wasm/shim.cc
+++ b/wasm/shim.cc
@@ -1,14 +1,18 @@
+#include <qpdf/Constants.h>
 #include <qpdf/QPDF.hh>
 #include <qpdf/QPDFWriter.hh>
 #include <exception>
 
-extern "C" int qpdf_wasm_compress(char const* infilename, char const* outfilename)
+extern "C" int
+qpdf_wasm_compress(char const* infilename, char const* outfilename)
 {
     try {
         QPDF pdf;
         pdf.processFile(infilename);
         QPDFWriter w(pdf, outfilename);
-        w.setCompressStreams(true);
+        w.setObjectStreamMode(qpdf_o_generate);
+        w.setStreamDataMode(qpdf_s_compress);
+        w.setRecompressFlate(true);
         w.write();
         return 0;
     } catch (std::exception& e) {


### PR DESCRIPTION
## Summary
- ensure WASM wrapper generates object streams and recompresses all streams

## Testing
- `clang-format -i wasm/shim.cc`


------
https://chatgpt.com/codex/tasks/task_e_6899824aed408330b82388d2bd66f4b4