### PR TITLE
Add configurable compression levels for WASM

### DIFF
--- a/wasm/index.html
+++ b/wasm/index.html
@@ -6,6 +6,11 @@
 </head>
 <body>
   <input type="file" id="file" accept="application/pdf" />
+  <select id="level">
+    <option value="fast">Fast</option>
+    <option value="balanced" selected>Balanced</option>
+    <option value="smallest">Smallest</option>
+  </select>
   <button id="run">Compress</button>
   <script src="qpdf-wasm.js"></script>
   <script>
@@ -21,7 +26,7 @@
       ready = true;
     });
 
-    function compress(input, output) {
+    function compress(input, output, level) {
       const encoder = new TextEncoder();
       const inBuf = encoder.encode(input + '\0');
       const inPtr = qpdf._malloc(inBuf.length);
@@ -29,9 +34,13 @@
       const outBuf = encoder.encode(output + '\0');
       const outPtr = qpdf._malloc(outBuf.length);
       qpdf.HEAPU8.set(outBuf, outPtr);
-      qpdf._qpdf_wasm_compress(inPtr, outPtr);
+      const lvlBuf = encoder.encode(level + '\0');
+      const lvlPtr = qpdf._malloc(lvlBuf.length);
+      qpdf.HEAPU8.set(lvlBuf, lvlPtr);
+      qpdf._qpdf_wasm_compress(inPtr, outPtr, lvlPtr);
       qpdf._free(inPtr);
       qpdf._free(outPtr);
+      qpdf._free(lvlPtr);
     }
 
     document.getElementById('run').addEventListener('click', async () => {
@@ -52,7 +61,8 @@
         await file.stream().pipeTo(writable);
         const input = '/opfs/input.pdf';
         const output = '/opfs/output.pdf';
-        compress(input, output);
+        const level = document.getElementById('level').value;
+        compress(input, output, level);
         const outHandle = await root.getFileHandle('output.pdf');
         const outFile = await outHandle.getFile();
         const url = URL.createObjectURL(outFile);
@@ -66,7 +76,8 @@
       } else {
         const buf = new Uint8Array(await file.arrayBuffer());
         qpdf.FS.writeFile('input.pdf', buf);
-        compress('input.pdf', 'output.pdf');
+        const level = document.getElementById('level').value;
+        compress('input.pdf', 'output.pdf', level);
         const out = qpdf.FS.readFile('output.pdf');
         const blob = new Blob([out], { type: 'application/pdf' });
         const url = URL.createObjectURL(blob);

--- a/wasm/shim.cc
+++ b/wasm/shim.cc
@@ -1,18 +1,114 @@
 #include <qpdf/Constants.h>
 #include <qpdf/QPDF.hh>
 #include <qpdf/QPDFWriter.hh>
+#include <qpdf/Buffer.hh>
+#include <zlib.h>
+#include <array>
+#include <cmath>
 #include <exception>
+#include <vector>
+#include <string>
+
+static double
+shannon_entropy(unsigned char const* data, size_t len)
+{
+    if (len == 0) {
+        return 0.0;
+    }
+    std::array<size_t, 256> counts = {0};
+    for (size_t i = 0; i < len; ++i) {
+        ++counts[data[i]];
+    }
+    double ent = 0.0;
+    double f = static_cast<double>(len);
+    for (auto c: counts) {
+        if (c) {
+            double p = c / f;
+            ent -= p * std::log2(p);
+        }
+    }
+    return ent;
+}
+
+static void
+compress_stream(QPDFObjectHandle& oh, std::shared_ptr<Buffer> buf, int level)
+{
+    size_t inlen = buf->getSize();
+    unsigned char const* in = buf->getBuffer();
+    uLongf outlen = compressBound(inlen);
+    std::string out;
+    out.resize(outlen);
+    if (compress2(reinterpret_cast<unsigned char*>(out.data()), &outlen, in, inlen, level) !=
+        Z_OK) {
+        throw std::runtime_error("compression failed");
+    }
+    out.resize(outlen);
+    oh.replaceStreamData(
+        out, QPDFObjectHandle::newName("/FlateDecode"), QPDFObjectHandle::newNull());
+}
 
 extern "C" int
-qpdf_wasm_compress(char const* infilename, char const* outfilename)
+qpdf_wasm_compress(char const* infilename, char const* outfilename, char const* level)
 {
     try {
         QPDF pdf;
         pdf.processFile(infilename);
+
+        int lvl = 6; // balanced
+        std::string l = level ? level : "";
+        if (l == "fast") {
+            lvl = 1;
+        } else if (l == "smallest") {
+            lvl = 9;
+        }
+
+        for (auto& oh: pdf.getAllObjects()) {
+            if (!oh.isStream()) {
+                continue;
+            }
+
+            bool skip = false;
+            auto dict = oh.getDict();
+            auto f = dict.getKey("/Filter");
+            std::vector<std::string> filters;
+            if (f.isName()) {
+                filters.push_back(f.getName());
+            } else if (f.isArray()) {
+                for (auto& item: f.getArrayAsVector()) {
+                    if (item.isName()) {
+                        filters.push_back(item.getName());
+                    }
+                }
+            }
+
+            for (auto const& name: filters) {
+                if (name == "/DCTDecode" || name == "/JPXDecode" || name == "/JBIG2Decode" ||
+                    name == "/CCITTFaxDecode") {
+                    skip = true;
+                    break;
+                }
+            }
+
+            if (skip) {
+                continue;
+            }
+
+            if (filters.empty()) {
+                auto buf = oh.getStreamData(qpdf_dl_none);
+                if (shannon_entropy(buf->getBuffer(), buf->getSize()) > 7.9) {
+                    continue;
+                }
+                compress_stream(oh, buf, lvl);
+            } else {
+                auto buf = oh.getStreamData(qpdf_dl_specialized);
+                compress_stream(oh, buf, lvl);
+            }
+        }
+
         QPDFWriter w(pdf, outfilename);
         w.setObjectStreamMode(qpdf_o_generate);
-        w.setStreamDataMode(qpdf_s_compress);
-        w.setRecompressFlate(true);
+        w.setCompressStreams(false);
+        w.setRecompressFlate(false);
         w.write();
         return 0;
     } catch (std::exception& e) {


### PR DESCRIPTION
## Summary
- Allow compression level selection from browser UI
- Analyze each PDF stream and skip recompression for certain filters or high entropy data
- Recompress remaining streams with requested level

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_689aa0bdad2c8330b56ecf8f67798c58