### PR TITLE
Enable C++ exceptions for WASM compression

### DIFF
--- a/build-scripts/build-wasm
+++ b/build-scripts/build-wasm
@@ -21,7 +21,8 @@ configure() {
         -DQPDF_BUILD_TESTS=OFF \
         -DQPDF_BUILD_DOC=OFF \
         -DQPDF_BUILD_EXAMPLES=OFF \
-        -DBUILD_SHARED_LIBS=OFF
+        -DBUILD_SHARED_LIBS=OFF \
+        -DCMAKE_CXX_FLAGS="-fexceptions"
 }
 
 build() {
@@ -36,6 +37,7 @@ build() {
         -s FORCE_FILESYSTEM=1 \
         -s EXPORTED_FUNCTIONS='["_qpdf_wasm_compress","_malloc","_free"]' \
         -s EXPORTED_RUNTIME_METHODS='["FS"]' \
+        -fexceptions -s DISABLE_EXCEPTION_CATCHING=0 \
         -o "$BUILD_DIR/qpdf-wasm.js"
     cp "$SRCDIR/wasm/index.html" "$BUILD_DIR"
 }

--- a/build-scripts/build-wasm-no-config
+++ b/build-scripts/build-wasm-no-config
@@ -26,6 +26,7 @@ build() {
         -s FORCE_FILESYSTEM=1 \
         -s EXPORTED_FUNCTIONS='["_qpdf_wasm_compress","_malloc","_free"]' \
         -s EXPORTED_RUNTIME_METHODS='["FS"]' \
+        -fexceptions -s DISABLE_EXCEPTION_CATCHING=0 \
         -o "$BUILD_DIR/qpdf-wasm.js"
     cp "$SRCDIR/wasm/index.html" "$BUILD_DIR"
 }

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -40,12 +40,10 @@
       qpdf.HEAPU8.set(lvlBuf, lvlPtr);
       const rc = qpdf._qpdf_wasm_compress(inPtr, outPtr, lvlPtr);
       console.log('qpdf_wasm_compress returned', rc);
-      if (rc !== 0) {
-        console.error('Compression failed');
-      }
       qpdf._free(inPtr);
       qpdf._free(outPtr);
       qpdf._free(lvlPtr);
+      return rc;
     }
 
     document.getElementById('run').addEventListener('click', async () => {
@@ -69,7 +67,10 @@
           const input = '/opfs/input.pdf';
           const output = '/opfs/output.pdf';
           const level = document.getElementById('level').value;
-          compress(input, output, level);
+          const rc = compress(input, output, level);
+          if (rc !== 0) {
+            throw new Error('Compression failed');
+          }
           const outHandle = await root.getFileHandle('output.pdf');
           const outFile = await outHandle.getFile();
           const url = URL.createObjectURL(outFile);
@@ -85,7 +86,10 @@
           const buf = new Uint8Array(await file.arrayBuffer());
           qpdf.FS.writeFile('input.pdf', buf);
           const level = document.getElementById('level').value;
-          compress('input.pdf', 'output.pdf', level);
+          const rc = compress('input.pdf', 'output.pdf', level);
+          if (rc !== 0) {
+            throw new Error('Compression failed');
+          }
           const out = qpdf.FS.readFile('output.pdf');
           const blob = new Blob([out], { type: 'application/pdf' });
           const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- allow qpdf's wasm build to handle C++ exceptions
- stop reading output file when compression fails

## Testing
- `bash -n build-scripts/build-wasm build-scripts/build-wasm-no-config`


------
https://chatgpt.com/codex/tasks/task_e_689abaf526d48330b8a48d2b33703390