### PR TITLE
Gracefully handle missing zopfli support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If qpdf is built with [zopfli](https://github.com/google/zopfli) support and the
 
 The environment variable `QPDF_ZOPFLI` can be set to the following values:
 * `disabled` (or unset): do not use zopfli
-* `force`: use zopfli; fail if zopfli is not compiled in
+* `force`: use zopfli if available; otherwise warn and fall back to zlib
 * `silent`: use zopfli if available; otherwise silently fall back to zlib
 * any other value: use zopfli if available, and warn if not
 

--- a/include/qpdf/Pl_Flate.hh
+++ b/include/qpdf/Pl_Flate.hh
@@ -81,8 +81,8 @@ class QPDF_DLL_CLASS Pl_Flate: public Pipeline
     // If zopfli is supported, returns true. Otherwise, check the QPDF_ZOPFLI
     // environment variable as follows:
     // - "disabled" or "silent": return true
-    // - "force": qpdf_exit_error, throw an exception
-    // - Any other value: issue a warning, and return false
+    // - "force": issue a warning and return false
+    // - Any other value: issue a warning and return false
     QPDF_DLL
     static bool zopfli_check_env(QPDFLogger* logger = nullptr);
 

--- a/libqpdf/Pl_Flate.cc
+++ b/libqpdf/Pl_Flate.cc
@@ -376,7 +376,10 @@ Pl_Flate::zopfli_check_env(QPDFLogger* logger)
     // This behavior is known in QPDFJob (for the --zopfli argument), Pl_Flate.hh, README.md,
     // and the manual. Do a case-insensitive search for zopfli if changing the behavior.
     if (value == "force") {
-        throw std::runtime_error("QPDF_ZOPFLI=force, and zopfli support is not enabled");
+        logger->warn("QPDF_ZOPFLI=force is set, but libqpdf was not built with zopfli support\n");
+        logger->warn(
+            "Set QPDF_ZOPFLI=silent to suppress this warning and use zopfli when available.\n");
+        return false;
     }
     logger->warn("QPDF_ZOPFLI is set, but libqpdf was not built with zopfli support\n");
     logger->warn(

--- a/libqpdf/QPDFJob_argv.cc
+++ b/libqpdf/QPDFJob_argv.cc
@@ -116,7 +116,9 @@ ArgParser::argZopfli()
             logger->info("zopfli support is enabled but not active\n");
             logger->info("Set the environment variable QPDF_ZOPFLI to activate.\n");
             logger->info("* QPDF_ZOPFLI=disabled or QPDF_ZOPFLI not set: don't use zopfli.\n");
-            logger->info("* QPDF_ZOPFLI=force: use zopfli, and fail if not available.\n");
+            logger->info(
+                "* QPDF_ZOPFLI=force: use zopfli if available; otherwise warn and fall back to "
+                "zlib.\n");
             logger->info(
                 "* QPDF_ZOPFLI=silent: use zopfli if available and silently fall back if not.\n");
             logger->info(

--- a/manual/cli.rst
+++ b/manual/cli.rst
@@ -4068,7 +4068,8 @@ Here are the supported values for ``QPDF_ZOPFLI``:
      - use zopfli if available; otherwise silently fall back to zlib
 
    - - ``force``
-     - use zopfli if available; fail with an error if not available
+     - use zopfli if available; otherwise issue a warning and fall
+       back to zlib
 
    - - any other value
      - use zopfli if available; otherwise issue a warning and fall

--- a/qpdf/qtest/zopfli.test
+++ b/qpdf/qtest/zopfli.test
@@ -51,10 +51,10 @@ if (! $zopfli_enabled) {
                  {$td->COMMAND => "qpdf-test-compare a.pdf minimal-out.pdf"},
                  {$td->FILE => "minimal-out.pdf", $td->EXIT_STATUS => 0});
 
-    $td->runtest("zopfli error",
+    $td->runtest("zopfli force fallback",
                  {$td->COMMAND => "QPDF_ZOPFLI=force qpdf minimal.pdf a.pdf"},
-                 {$td->REGEXP => "QPDF_ZOPFLI=force, and zopfli support is not enabled",
-                      $td->EXIT_STATUS => 2},
+                 {$td->REGEXP => "QPDF_ZOPFLI=force is set, but libqpdf was not built with zopfli support",
+                      $td->EXIT_STATUS => 3},
                  $td->NORMALIZE_NEWLINES);
 
 } else {

--- a/zlib-flate/qtest/zf.test
+++ b/zlib-flate/qtest/zf.test
@@ -73,8 +73,8 @@ if ($zopfli =~ m/^0/) {
                  $td->NORMALIZE_NEWLINES);
     $td->runtest("force",
                  {$td->COMMAND => "QPDF_ZOPFLI=force zlib-flate -compress < a.uncompressed"},
-                 {$td->REGEXP => "QPDF_ZOPFLI=force, and zopfli support is not enabled",
-                      $td->EXIT_STATUS => 2},
+                 {$td->REGEXP => "QPDF_ZOPFLI=force is set, but libqpdf was not built with zopfli support",
+                      $td->EXIT_STATUS => 0},
                  $td->NORMALIZE_NEWLINES);
     $td->runtest("silent",
                  {$td->COMMAND => "QPDF_ZOPFLI=silent zlib-flate -compress < a.uncompressed > $dev_null"},


### PR DESCRIPTION
## Summary
- warn and fall back to zlib when QPDF_ZOPFLI=force is set but zopfli isn't available
- document the new QPDF_ZOPFLI=force behavior across code and docs
- adjust zopfli tests for fallback semantics

## Testing
- `clang-format -i libqpdf/Pl_Flate.cc include/qpdf/Pl_Flate.hh libqpdf/QPDFJob_argv.cc`
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_689acdd267e4833097f84a79f442f77c