### PR TITLE
feat(wasm): add selectable compression levels with progress

### DIFF
--- a/build-scripts/build-wasm
+++ b/build-scripts/build-wasm
@@ -34,7 +34,7 @@ build() {
         -s USE_ZLIB=1 \
         -s USE_LIBJPEG=1 \
         -s FORCE_FILESYSTEM=1 \
-        -s EXPORTED_FUNCTIONS='["_qpdf_wasm_compress","_malloc","_free"]' \
+        -s EXPORTED_FUNCTIONS='["_qpdf_wasm_compress","_qpdf_wasm_get_progress","_malloc","_free"]' \
         -s EXPORTED_RUNTIME_METHODS='["FS"]' \
         -o "$BUILD_DIR/qpdf-wasm.js"
     cp "$SRCDIR/wasm/index.html" "$BUILD_DIR"

--- a/build-scripts/build-wasm-no-config
+++ b/build-scripts/build-wasm-no-config
@@ -24,7 +24,7 @@ build() {
         -s USE_ZLIB=1 \
         -s USE_LIBJPEG=1 \
         -s FORCE_FILESYSTEM=1 \
-        -s EXPORTED_FUNCTIONS='["_qpdf_wasm_compress","_malloc","_free"]' \
+        -s EXPORTED_FUNCTIONS='["_qpdf_wasm_compress","_qpdf_wasm_get_progress","_malloc","_free"]' \
         -s EXPORTED_RUNTIME_METHODS='["FS"]' \
         -o "$BUILD_DIR/qpdf-wasm.js"
     cp "$SRCDIR/wasm/index.html" "$BUILD_DIR"

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -6,7 +6,13 @@
 </head>
 <body>
   <input type="file" id="file" accept="application/pdf" />
+  <select id="mode">
+    <option value="default">Default</option>
+    <option value="fast">Fast</option>
+    <option value="smallest">Smallest</option>
+  </select>
   <button id="run">Compress</button>
+  <progress id="progress" value="0" max="100"></progress>
   <script src="qpdf-wasm.js"></script>
   <script>
     let ready = false;
@@ -21,7 +27,7 @@
       ready = true;
     });
 
-    function compress(input, output) {
+    function compress(input, output, level) {
       const encoder = new TextEncoder();
       const inBuf = encoder.encode(input + '\0');
       const inPtr = qpdf._malloc(inBuf.length);
@@ -29,9 +35,14 @@
       const outBuf = encoder.encode(output + '\0');
       const outPtr = qpdf._malloc(outBuf.length);
       qpdf.HEAPU8.set(outBuf, outPtr);
-      qpdf._qpdf_wasm_compress(inPtr, outPtr);
+      const ratePtr = qpdf._malloc(8);
+      qpdf._qpdf_wasm_compress(inPtr, outPtr, level, ratePtr);
+      const rate = qpdf.HEAPF64[ratePtr >> 3];
+      const progress = qpdf._qpdf_wasm_get_progress();
       qpdf._free(inPtr);
       qpdf._free(outPtr);
+      qpdf._free(ratePtr);
+      return { rate, progress };
     }
 
     document.getElementById('run').addEventListener('click', async () => {
@@ -45,38 +56,112 @@
         return;
       }
       const file = fi.files[0];
+      const mode = document.getElementById('mode').value;
+      const progressBar = document.getElementById('progress');
+      progressBar.value = 0;
       if (qpdf.FS && qpdf.FS.filesystems?.OPFS && navigator.storage?.getDirectory) {
         const root = await navigator.storage.getDirectory();
         const inputHandle = await root.getFileHandle('input.pdf', { create: true });
         const writable = await inputHandle.createWritable();
         await file.stream().pipeTo(writable);
         const input = '/opfs/input.pdf';
-        const output = '/opfs/output.pdf';
-        compress(input, output);
-        const outHandle = await root.getFileHandle('output.pdf');
-        const outFile = await outHandle.getFile();
-        const url = URL.createObjectURL(outFile);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = 'compressed.pdf';
-        a.click();
-        URL.revokeObjectURL(url);
-        await root.removeEntry('input.pdf');
-        await root.removeEntry('output.pdf');
+
+        if (mode === 'default') {
+          const levels = [1, 5, 9];
+          const outputs = ['fast.pdf', 'mid.pdf', 'small.pdf'];
+          let best = { rate: Infinity, idx: 0 };
+          for (let i = 0; i < levels.length; ++i) {
+            const r = compress(input, `/opfs/${outputs[i]}`, levels[i]);
+            if (r.rate < best.rate) best = { rate: r.rate, idx: i };
+          }
+          if (best.rate >= 1) {
+            alert('File is already compact');
+            await root.removeEntry('input.pdf');
+            for (const o of outputs) await root.removeEntry(o);
+            return;
+          }
+          const outHandle = await root.getFileHandle(outputs[best.idx]);
+          const outFile = await outHandle.getFile();
+          progressBar.value = qpdf._qpdf_wasm_get_progress();
+          const url = URL.createObjectURL(outFile);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = 'compressed.pdf';
+          a.click();
+          URL.revokeObjectURL(url);
+          await root.removeEntry('input.pdf');
+          for (const o of outputs) await root.removeEntry(o);
+        } else {
+          const level = mode === 'fast' ? 1 : 9;
+          const output = '/opfs/output.pdf';
+          const r = compress(input, output, level);
+          if (r.rate >= 1) {
+            alert('File is already compact');
+            await root.removeEntry('input.pdf');
+            await root.removeEntry('output.pdf');
+            return;
+          }
+          const outHandle = await root.getFileHandle('output.pdf');
+          const outFile = await outHandle.getFile();
+          progressBar.value = qpdf._qpdf_wasm_get_progress();
+          const url = URL.createObjectURL(outFile);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = 'compressed.pdf';
+          a.click();
+          URL.revokeObjectURL(url);
+          await root.removeEntry('input.pdf');
+          await root.removeEntry('output.pdf');
+        }
       } else {
         const buf = new Uint8Array(await file.arrayBuffer());
         qpdf.FS.writeFile('input.pdf', buf);
-        compress('input.pdf', 'output.pdf');
-        const out = qpdf.FS.readFile('output.pdf');
-        const blob = new Blob([out], { type: 'application/pdf' });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = 'compressed.pdf';
-        a.click();
-        URL.revokeObjectURL(url);
-        qpdf.FS.unlink('input.pdf');
-        qpdf.FS.unlink('output.pdf');
+        if (mode === 'default') {
+          const levels = [1, 5, 9];
+          const outputs = ['fast.pdf', 'mid.pdf', 'small.pdf'];
+          let best = { rate: Infinity, idx: 0 };
+          for (let i = 0; i < levels.length; ++i) {
+            const r = compress('input.pdf', outputs[i], levels[i]);
+            if (r.rate < best.rate) best = { rate: r.rate, idx: i };
+          }
+          if (best.rate >= 1) {
+            alert('File is already compact');
+            qpdf.FS.unlink('input.pdf');
+            for (const o of outputs) qpdf.FS.unlink(o);
+            return;
+          }
+          const out = qpdf.FS.readFile(outputs[best.idx]);
+          progressBar.value = qpdf._qpdf_wasm_get_progress();
+          const blob = new Blob([out], { type: 'application/pdf' });
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = 'compressed.pdf';
+          a.click();
+          URL.revokeObjectURL(url);
+          qpdf.FS.unlink('input.pdf');
+          for (const o of outputs) qpdf.FS.unlink(o);
+        } else {
+          const level = mode === 'fast' ? 1 : 9;
+          const r = compress('input.pdf', 'output.pdf', level);
+          if (r.rate >= 1) {
+            alert('File is already compact');
+            qpdf.FS.unlink('input.pdf');
+            qpdf.FS.unlink('output.pdf');
+            return;
+          }
+          const out = qpdf.FS.readFile('output.pdf');
+          progressBar.value = qpdf._qpdf_wasm_get_progress();
+          const blob = new Blob([out], { type: 'application/pdf' });
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = 'compressed.pdf';
+          a.click();
+          URL.revokeObjectURL(url);
+          qpdf.FS.unlink('input.pdf');
+          qpdf.FS.unlink('output.pdf');
+        }
       }
     });
   </script>

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -70,9 +70,11 @@
           const levels = [1, 5, 9];
           const outputs = ['fast.pdf', 'mid.pdf', 'small.pdf'];
           let best = { rate: Infinity, idx: 0 };
+          let progress = 0;
           for (let i = 0; i < levels.length; ++i) {
             const r = compress(input, `/opfs/${outputs[i]}`, levels[i]);
             if (r.rate < best.rate) best = { rate: r.rate, idx: i };
+            progress = r.progress;
           }
           if (best.rate >= 1) {
             alert('File is already compact');
@@ -82,7 +84,7 @@
           }
           const outHandle = await root.getFileHandle(outputs[best.idx]);
           const outFile = await outHandle.getFile();
-          progressBar.value = qpdf._qpdf_wasm_get_progress();
+          progressBar.value = progress;
           const url = URL.createObjectURL(outFile);
           const a = document.createElement('a');
           a.href = url;
@@ -103,7 +105,7 @@
           }
           const outHandle = await root.getFileHandle('output.pdf');
           const outFile = await outHandle.getFile();
-          progressBar.value = qpdf._qpdf_wasm_get_progress();
+          progressBar.value = r.progress;
           const url = URL.createObjectURL(outFile);
           const a = document.createElement('a');
           a.href = url;
@@ -120,9 +122,11 @@
           const levels = [1, 5, 9];
           const outputs = ['fast.pdf', 'mid.pdf', 'small.pdf'];
           let best = { rate: Infinity, idx: 0 };
+          let progress = 0;
           for (let i = 0; i < levels.length; ++i) {
             const r = compress('input.pdf', outputs[i], levels[i]);
             if (r.rate < best.rate) best = { rate: r.rate, idx: i };
+            progress = r.progress;
           }
           if (best.rate >= 1) {
             alert('File is already compact');
@@ -131,7 +135,7 @@
             return;
           }
           const out = qpdf.FS.readFile(outputs[best.idx]);
-          progressBar.value = qpdf._qpdf_wasm_get_progress();
+          progressBar.value = progress;
           const blob = new Blob([out], { type: 'application/pdf' });
           const url = URL.createObjectURL(blob);
           const a = document.createElement('a');
@@ -151,7 +155,7 @@
             return;
           }
           const out = qpdf.FS.readFile('output.pdf');
-          progressBar.value = qpdf._qpdf_wasm_get_progress();
+          progressBar.value = r.progress;
           const blob = new Blob([out], { type: 'application/pdf' });
           const url = URL.createObjectURL(blob);
           const a = document.createElement('a');

--- a/wasm/shim.cc
+++ b/wasm/shim.cc
@@ -1,19 +1,47 @@
 #include <qpdf/Constants.h>
+#include <qpdf/Pl_Flate.hh>
 #include <qpdf/QPDF.hh>
 #include <qpdf/QPDFWriter.hh>
 #include <exception>
+#include <atomic>
+#include <fstream>
+#include <memory>
+
+static std::atomic<int> g_progress{0};
 
 extern "C" int
-qpdf_wasm_compress(char const* infilename, char const* outfilename)
+qpdf_wasm_get_progress()
+{
+    return g_progress.load();
+}
+
+extern "C" int
+qpdf_wasm_compress(
+    char const* infilename,
+    char const* outfilename,
+    int level,
+    double* rate)
 {
     try {
+        g_progress.store(0);
         QPDF pdf;
         pdf.processFile(infilename);
         QPDFWriter w(pdf, outfilename);
         w.setObjectStreamMode(qpdf_o_generate);
         w.setStreamDataMode(qpdf_s_compress);
         w.setRecompressFlate(true);
+        Pl_Flate::setCompressionLevel(level);
+        w.registerProgressReporter(std::make_shared<QPDFWriter::FunctionProgressReporter>(
+            [](int p) { g_progress.store(p); }));
         w.write();
+        std::ifstream in(infilename, std::ifstream::binary | std::ifstream::ate);
+        std::ifstream out(outfilename, std::ifstream::binary | std::ifstream::ate);
+        if (rate && in && out) {
+            double in_size = static_cast<double>(in.tellg());
+            double out_size = static_cast<double>(out.tellg());
+            *rate = (in_size > 0) ? (out_size / in_size) : 0.0;
+        }
+        g_progress.store(100);
         return 0;
     } catch (std::exception& e) {
         return 1;


### PR DESCRIPTION
## Summary
- add fast, smallest, and multi-pass default compression options
- expose compression ratio and progress from wasm shim

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_689c29522d2c83308825b9200cf31677