### PR TITLE
Improve wasm compression demo

### DIFF
--- a/wasm/index.html
+++ b/wasm/index.html
@@ -3,21 +3,26 @@
 <head>
   <meta charset="utf-8" />
   <title>qpdf wasm demo</title>
+  <style>
+    #progress {
+      width: 50px;
+      height: 50px;
+      border-radius: 50%;
+      background: conic-gradient(#e6e6e6 0%, #e6e6e6 100%);
+    }
+  </style>
 </head>
 <body>
   <input type="file" id="file" accept="application/pdf" />
-  <select id="mode">
-    <option value="default">Default</option>
-    <option value="fast">Fast</option>
-    <option value="smallest">Smallest</option>
-  </select>
+  <label>JPEG quality:
+    <input type="number" id="jpeg" min="60" max="75" value="75" />
+  </label>
   <button id="run">Compress</button>
-  <progress id="progress" value="0" max="100"></progress>
+  <div id="progress"></div>
   <script src="qpdf-wasm.js"></script>
   <script>
     let ready = false;
     let qpdf;
-
     Module().then((mod) => {
       qpdf = mod;
       if (qpdf.FS && qpdf.FS.filesystems && qpdf.FS.filesystems.OPFS) {
@@ -27,7 +32,7 @@
       ready = true;
     });
 
-    function compress(input, output, level) {
+    function compress(input, output, level, jpeg) {
       const encoder = new TextEncoder();
       const inBuf = encoder.encode(input + '\0');
       const inPtr = qpdf._malloc(inBuf.length);
@@ -36,7 +41,7 @@
       const outPtr = qpdf._malloc(outBuf.length);
       qpdf.HEAPU8.set(outBuf, outPtr);
       const ratePtr = qpdf._malloc(8);
-      qpdf._qpdf_wasm_compress(inPtr, outPtr, level, ratePtr);
+      qpdf._qpdf_wasm_compress(inPtr, outPtr, level, jpeg, ratePtr);
       const rate = qpdf.HEAPF64[ratePtr >> 3];
       const progress = qpdf._qpdf_wasm_get_progress();
       qpdf._free(inPtr);
@@ -55,107 +60,63 @@
         alert('Select a PDF first');
         return;
       }
+      const jpeg = parseInt(document.getElementById('jpeg').value) || 75;
+      const progressEl = document.getElementById('progress');
+      progressEl.style.background = 'conic-gradient(#e6e6e6 0%, #e6e6e6 100%)';
       const file = fi.files[0];
-      const mode = document.getElementById('mode').value;
-      const progressBar = document.getElementById('progress');
-      progressBar.value = 0;
+      const levels = [3, 6, 9];
+      const outputs = ['l3.pdf', 'l6.pdf', 'l9.pdf'];
+      const ratios = [];
       if (qpdf.FS && qpdf.FS.filesystems?.OPFS && navigator.storage?.getDirectory) {
         const root = await navigator.storage.getDirectory();
         const inputHandle = await root.getFileHandle('input.pdf', { create: true });
         const writable = await inputHandle.createWritable();
         await file.stream().pipeTo(writable);
         const input = '/opfs/input.pdf';
-
-        if (mode === 'default') {
-          const levels = [1, 5, 9];
-          const outputs = ['fast.pdf', 'mid.pdf', 'small.pdf'];
-          let best = { rate: Infinity, idx: 0 };
-          let progress = 0;
-          for (let i = 0; i < levels.length; ++i) {
-            const r = compress(input, `/opfs/${outputs[i]}`, levels[i]);
-            if (r.rate < best.rate) best = { rate: r.rate, idx: i };
-            progress = r.progress;
-          }
-          if (best.rate >= 1) {
-            alert('File is already compact');
-            await root.removeEntry('input.pdf');
-            for (const o of outputs) await root.removeEntry(o);
-            return;
-          }
+        let best = { rate: 0, idx: -1 };
+        let progress = 0;
+        for (let i = 0; i < levels.length; ++i) {
+          const r = compress(input, `/opfs/${outputs[i]}`, levels[i], jpeg);
+          ratios.push(r.rate);
+          if (r.rate > best.rate) best = { rate: r.rate, idx: i };
+          progress = r.progress;
+        }
+        console.log('ratios', ratios);
+        progressEl.style.background = `conic-gradient(#4d90fe ${progress}%, #e6e6e6 0)`;
+        if (best.rate <= 0) {
+          alert('File is already compact');
+        } else {
           const outHandle = await root.getFileHandle(outputs[best.idx]);
           const outFile = await outHandle.getFile();
-          progressBar.value = progress;
           const url = URL.createObjectURL(outFile);
           const a = document.createElement('a');
           a.href = url;
           a.download = 'compressed.pdf';
           a.click();
           URL.revokeObjectURL(url);
-          await root.removeEntry('input.pdf');
-          for (const o of outputs) await root.removeEntry(o);
-        } else {
-          const level = mode === 'fast' ? 1 : 9;
-          const output = '/opfs/output.pdf';
-          const r = compress(input, output, level);
-          if (r.rate >= 1) {
-            alert('File is already compact');
-            await root.removeEntry('input.pdf');
-            await root.removeEntry('output.pdf');
-            return;
-          }
-          const outHandle = await root.getFileHandle('output.pdf');
-          const outFile = await outHandle.getFile();
-          progressBar.value = r.progress;
-          const url = URL.createObjectURL(outFile);
-          const a = document.createElement('a');
-          a.href = url;
-          a.download = 'compressed.pdf';
-          a.click();
-          URL.revokeObjectURL(url);
-          await root.removeEntry('input.pdf');
-          await root.removeEntry('output.pdf');
+          alert(`Saved ${Math.round(best.rate * 100)}%`);
+        }
+        await root.removeEntry('input.pdf');
+        for (const o of outputs) {
+          try { await root.removeEntry(o); } catch (e) {}
         }
       } else {
         const buf = new Uint8Array(await file.arrayBuffer());
         qpdf.FS.writeFile('input.pdf', buf);
-        if (mode === 'default') {
-          const levels = [1, 5, 9];
-          const outputs = ['fast.pdf', 'mid.pdf', 'small.pdf'];
-          let best = { rate: Infinity, idx: 0 };
-          let progress = 0;
-          for (let i = 0; i < levels.length; ++i) {
-            const r = compress('input.pdf', outputs[i], levels[i]);
-            if (r.rate < best.rate) best = { rate: r.rate, idx: i };
-            progress = r.progress;
-          }
-          if (best.rate >= 1) {
-            alert('File is already compact');
-            qpdf.FS.unlink('input.pdf');
-            for (const o of outputs) qpdf.FS.unlink(o);
-            return;
-          }
-          const out = qpdf.FS.readFile(outputs[best.idx]);
-          progressBar.value = progress;
-          const blob = new Blob([out], { type: 'application/pdf' });
-          const url = URL.createObjectURL(blob);
-          const a = document.createElement('a');
-          a.href = url;
-          a.download = 'compressed.pdf';
-          a.click();
-          URL.revokeObjectURL(url);
-          qpdf.FS.unlink('input.pdf');
-          for (const o of outputs) qpdf.FS.unlink(o);
+        let best = { rate: 0, idx: -1 };
+        let progress = 0;
+        for (let i = 0; i < levels.length; ++i) {
+          const r = compress('input.pdf', outputs[i], levels[i], jpeg);
+          ratios.push(r.rate);
+          if (r.rate > best.rate) best = { rate: r.rate, idx: i };
+          progress = r.progress;
+        }
+        console.log('ratios', ratios);
+        progressEl.style.background = `conic-gradient(#4d90fe ${progress}%, #e6e6e6 0)`;
+        if (best.rate <= 0) {
+          alert('File is already compact');
         } else {
-          const level = mode === 'fast' ? 1 : 9;
-          const r = compress('input.pdf', 'output.pdf', level);
-          if (r.rate >= 1) {
-            alert('File is already compact');
-            qpdf.FS.unlink('input.pdf');
-            qpdf.FS.unlink('output.pdf');
-            return;
-          }
-          const out = qpdf.FS.readFile('output.pdf');
-          progressBar.value = r.progress;
+          const out = qpdf.FS.readFile(outputs[best.idx]);
           const blob = new Blob([out], { type: 'application/pdf' });
           const url = URL.createObjectURL(blob);
           const a = document.createElement('a');
@@ -163,11 +124,15 @@
           a.download = 'compressed.pdf';
           a.click();
           URL.revokeObjectURL(url);
-          qpdf.FS.unlink('input.pdf');
-          qpdf.FS.unlink('output.pdf');
+          alert(`Saved ${Math.round(best.rate * 100)}%`);
+        }
+        qpdf.FS.unlink('input.pdf');
+        for (const o of outputs) {
+          try { qpdf.FS.unlink(o); } catch (e) {}
         }
       }
     });
   </script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- remove unused `pdf-auto-compress.py` example
- add JPEG quality control and progress circle to wasm demo
- use QPDFJob in wasm shim to try compression levels 3, 6, and 9 with image optimization
- explicitly set compression level for each preset

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_689d4e0497708330a7d7f4bc02107846